### PR TITLE
Fix Conway link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ $ cargo run --release --bin horiz_tp
 [11]: https://github.com/cbiffle/m4vgalib
 [12]: fx/
 
-[conway]: m4demos/src/bin/conway
+[conway]: m4demos/src/bin/conway.rs
 [hires_text]: m4demos/src/bin/hires_text.rs
 [horiz_tp]: m4demos/src/bin/horiz_tp.rs
 [poly3]: m4demos/src/bin/poly3/


### PR DESCRIPTION
This fixes a 404-ing link in README.

Thanks for this repo! :)